### PR TITLE
Ensure that kvm module is loaded before taking any action

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,17 +18,24 @@
     msg: "The system doesn't seem to have Intel nor AMD virtualization support."
   when: intel_proccesor.rc != 0 and amd_proccesor != 0
 
-- name: Set facts for Intel virtualization
+- name: Set fact for Intel virtualization
   set_fact:
-    nested_virtualization_test_path: "/sys/module/kvm_intel/parameters/nested"
     nested_virtualization_module_name: "kvm_intel"
   when: intel_proccesor.rc == 0
 
-- name: Set facts for AMD virtualization
+- name: Set fact for AMD virtualization
   set_fact:
-    nested_virtualization_test_path: "/sys/module/kvm_amd/parameters/nested"
     nested_virtualization_module_name: "kvm_amd"
   when: amd_proccesor.rc == 0
+
+- name: Set fact for nested virtualization test path
+  set_fact:
+    nested_virtualization_test_path: "/sys/module/{{ nested_virtualization_module_name }}/parameters/nested"
+
+- name: "Ensure {{ nested_virtualization_module_name }} module is available and loaded"
+  modprobe:
+    name: "{{ nested_virtualization_module_name }}"
+    state: present
 
 - name: Test status of nested virtualization
   shell: |


### PR DESCRIPTION
when we have this pipe we failed with:
FAILED! => {"changed": true, "cmd": "**set -e\ncat /sys/module/kvm_intel/parameters/nested\n**", "delta": "0:00:00.004861", "end": "2019-01-08 15:35:44.272014", "msg": "non-zero return code", "rc": 1, "start": "2019-01-08 15:35:44.267153", "stderr": "cat: /sys/module/kvm_intel/parameters/nested: No such file or directory", "stderr_lines": ["cat: /sys/module/kvm_intel/parameters/nested: No such file or directory"], "stdout": "", "stdout_lines": []}