### PR TITLE
Refactored role

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Role Variables
 
 ```yaml
 ---
-nested_virtualization_state: enabled / disabled
+nested_virtualization_state: present / absent
 ```
 
 Dependencies
@@ -38,7 +38,7 @@ Example Playbook
 - hosts: servers
   roles:
     - role: "nested-virtualization"
-      nested_virtualization_state: "disabled"
+      nested_virtualization_state: "absent"
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-nested_virtualization_state: "enabled"
+nested_virtualization_state: "present"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,10 +6,19 @@ galaxy_info:
   license: GPLv3
   min_ansible_version: 2.4
   platforms:
+  - name: Debian
+    versions:
+    - buster
+    - bullseye
   - name: EL
     versions:
     - 6
     - 7
+    - 8
+  - name: Ubuntu
+    versions:
+    - bionic
+    - focal
   galaxy_tags:
   - virt
   - virtualization

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: nested-virtualization
   author: Lukas Bednar
   description: "Ansible role to enable or disable nested virtualization"
   company: "Red Hat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
     line: "options {{ nested_virtualization_module_name }} nested=1"
     create: yes
   when:
-    - nested_virtualization_state == "enabled"
+    - nested_virtualization_state in ["present", "enabled"]
 
 - name: "Persist configuration in {{ nested_virtualization_kvm_config }}"
   lineinfile:
@@ -62,18 +62,18 @@
     state: absent
     create: yes
   when:
-    - nested_virtualization_state == "disabled"
+    - nested_virtualization_state in ["absent", "disabled"]
 
 # Desired state is enabled but real state is off
 - name: "Reload {{ nested_virtualization_module_name }} module"
   include_tasks: reload-module.yml
   when:
-    - nested_virtualization_state == "enabled"
+    - nested_virtualization_state in ["present", "enabled"]
     - actual_status.stdout in ['N', '0']
 
 # Desired state is disabled but real state is on
 - name: "Reload {{ nested_virtualization_module_name }} module"
   include_tasks: reload-module.yml
   when:
-    - nested_virtualization_state == "disabled"
+    - nested_virtualization_state in ["absent", "disabled"]
     - actual_status.stdout in ['Y', '1']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   shell: |
     set -e
     grep vmx {{ nested_virtualization_cpuinfo }}
+  changed_when: no
   ignore_errors: yes
   register: intel_processor
 
@@ -10,6 +11,7 @@
   shell: |
     set -e
     grep svm {{ nested_virtualization_cpuinfo }}
+  changed_when: no
   ignore_errors: yes
   register: amd_processor
 
@@ -41,6 +43,7 @@
   shell: |
     set -e
     cat {{ nested_virtualization_test_path }}
+  changed_when: no
   register: actual_status
 
 - name: "Persist configuration in {{ nested_virtualization_kvm_config }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,11 +69,11 @@
   include_tasks: reload-module.yml
   when:
     - nested_virtualization_state == "enabled"
-    - "'N' in actual_status.stdout or '0' in actual_status.stdout"
+    - actual_status.stdout in ['N', '0']
 
 # Desired state is disabled but real state is on
 - name: "Reload {{ nested_virtualization_module_name }} module"
   include_tasks: reload-module.yml
   when:
     - nested_virtualization_state == "disabled"
-    - "'Y' in actual_status.stdout or '1' in actual_status.stdout"
+    - actual_status.stdout in ['Y', '1']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,29 +4,29 @@
     set -e
     grep vmx {{ nested_virtualization_cpuinfo }}
   ignore_errors: yes
-  register: intel_proccesor
+  register: intel_processor
 
 - name: Check if AMD virtualization is supported
   shell: |
     set -e
     grep svm {{ nested_virtualization_cpuinfo }}
   ignore_errors: yes
-  register: amd_proccesor
+  register: amd_processor
 
 - name: Fail in case no Intel or AMD virtualization support is not detected.
   fail:
     msg: "The system doesn't seem to have Intel nor AMD virtualization support."
-  when: intel_proccesor.rc != 0 and amd_proccesor.rc != 0
+  when: intel_processor.rc != 0 and amd_processor.rc != 0
 
 - name: Set fact for Intel virtualization
   set_fact:
     nested_virtualization_module_name: "kvm_intel"
-  when: intel_proccesor.rc == 0
+  when: intel_processor.rc == 0
 
 - name: Set fact for AMD virtualization
   set_fact:
     nested_virtualization_module_name: "kvm_amd"
-  when: amd_proccesor.rc == 0
+  when: amd_processor.rc == 0
 
 - name: Set fact for nested virtualization test path
   set_fact:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -26,4 +26,4 @@
   hosts: docker_containers
   roles:
     - role: "nested-virtualization"
-      nested_virtualization_state: "disabled"
+      nested_virtualization_state: "absent"


### PR DESCRIPTION
Updated role name for Ansible Galaxy, added Debian and Ubuntu to the list of supported platforms, do not trigger changes when just reading data and accept `present`+`absent` in addition to the `enabled`+`disabled` to follow Ansible's style more closely.